### PR TITLE
Set vCPU limit to 1 across the board

### DIFF
--- a/endpoint.tf
+++ b/endpoint.tf
@@ -4,7 +4,7 @@ locals {
 
 module "endpoint" {
   source  = "relaycorp/awala-endpoint/google"
-  version = "1.8.2"
+  version = "1.8.9"
 
   backend_name     = var.pong_instance_name
   internet_address = var.internet_address

--- a/pong.tf
+++ b/pong.tf
@@ -58,7 +58,7 @@ resource "google_cloud_run_v2_service" "pong" {
         cpu_idle          = false
 
         limits = {
-          cpu    = 2
+          cpu    = 1
           memory = "512Mi"
         }
       }


### PR DESCRIPTION
Because the app won't take advantage of multiple cores.
